### PR TITLE
Fix js-yaml version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ascii"
   ],
   "dependencies": {
-    "js-yaml": "git://github.com/nodeca/js-yaml.git"
+    "js-yaml": ">= 0.3.5 < 1.0.0"
   },
   "devDependencies": {
     "vows":  ">= 0.6.1"


### PR DESCRIPTION
JS Yaml is in the npm now, so version can be fixed.
Version 1.0.0 will bring some backward incompatibility (require will return single document - not an array)
